### PR TITLE
Fix Sitemap

### DIFF
--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -3,7 +3,13 @@ permalink: /sitemap.xml
 eleventyExcludeFromCollections: true
 ---
 <?xml version="1.0" encoding="utf-8"?>
-<urlset xmlnx="http://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+  http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd
+  http://www.w3.org/1999/xhtml
+  http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd">
   {% for page in collections.all %}
     {% if not page.data.draft %}
     <url>


### PR DESCRIPTION
Signed-off-by: Andrew St Clair <andrew_stclair95@hotmail.com>

Error reported by google:
Your Sitemap or Sitemap index file does not properly declare the namespace.

This fixes that